### PR TITLE
CORE-2304 Add alias for serial4 and test cases for int4, serial4

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -7,7 +7,7 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
-@DataTypeInfo(name = "int", aliases = {"integer", "java.sql.Types.INTEGER", "java.lang.Integer", "serial", "int4"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name = "int", aliases = { "integer", "java.sql.Types.INTEGER", "java.lang.Integer", "serial", "int4", "serial4" }, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class IntType extends LiquibaseDataType {
 
     private boolean autoIncrement;

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -37,5 +37,7 @@ public class DataTypeFactoryTest extends Specification {
         "varchar(255) COLLATE Latin1_General_BIN" | null           | VarcharType.class | false
         "character varying(256)"                  | "varchar(256)" | VarcharType.class | false
         "serial8"                                 | "bigint"       | BigIntType        | true
+        "int4"                                    | "int"          | IntType.class     | false
+        "serial4"                                 | "int"          | IntType.class     | true
     }
 }


### PR DESCRIPTION
int4 and serial4 are Postgres-specific aliases
http://www.postgresql.org/docs/9.4/static/datatype.html#DATATYPE-TABLE
